### PR TITLE
Refactoriza validaciones de cuotas de depreciación

### DIFF
--- a/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/Common/Validation.cs
+++ b/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/Common/Validation.cs
@@ -53,8 +53,20 @@
         {
             return date != DateTime.MinValue && date <= new DateTime(2100,12,31);
         }
-
         protected bool Validate(DateTime? date)
+        {
+            if (date == null)
+                return true;
+
+            return this.Validate(date.Value);
+        }
+
+        protected bool ValidateDepreciationQuotaDateTime(DateTime date)
+        {
+            return date != DateTime.MinValue;
+        }
+
+        protected bool ValidateDepreciationQuotaDateTime(DateTime? date)
         {
             if (date == null)
                 return true;
@@ -100,7 +112,10 @@
         {
             return input != 0;
         }
-
+        protected bool ValidateDepreciationQuotaAmount(decimal input)
+        {
+            return input >= 0;
+        }
         protected string ReplaceInMessage(string message, params string[] list)
         {
             var keys = new List<(int,string)>();

--- a/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/Common/Validation.cs
+++ b/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/Common/Validation.cs
@@ -71,7 +71,7 @@
             if (date == null)
                 return true;
 
-            return this.Validate(date.Value);
+            return this.ValidateDepreciationQuotaDateTime(date.Value);
         }
 
         protected bool Validate(Guid id)

--- a/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/FixedAsset/DepreciationQuotaValidation.cs
+++ b/Importia.SDK/Implementations/a3innuva.Importia.SDK.Implementations/Validations/FixedAsset/DepreciationQuotaValidation.cs
@@ -9,10 +9,10 @@
         protected override void SetupValidations()
         {
             this.CreateRule(x => this.Validate(x.AccountingYear), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Ejercicio contable'"));
-            this.CreateRule(x => this.Validate(x.AccountingQuotaAmount), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Cuota contable'"));
-            this.CreateRule(x => this.Validate(x.FiscalQuotaAmount), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Cuota fiscal'"));
-            this.CreateRule(x => this.Validate(x.StartDate), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Inicio de periodo de amortización'"));
-            this.CreateRule(x => this.Validate(x.EndDate), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Fin de periodo de amortización'"));
+            this.CreateRule(x => this.ValidateDepreciationQuotaAmount(x.AccountingQuotaAmount), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Cuota contable'"));
+            this.CreateRule(x => this.ValidateDepreciationQuotaAmount(x.FiscalQuotaAmount), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Cuota fiscal'"));
+            this.CreateRule(x => this.ValidateDepreciationQuotaDateTime(x.StartDate), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Inicio de periodo de amortización'"));
+            this.CreateRule(x => this.ValidateDepreciationQuotaDateTime(x.EndDate), this.ReplaceInMessage(ValidationMessages.Mandatory, "'Fin de periodo de amortización'"));
         }
     }
 }

--- a/Importia.SDK/Tests/a3innuva.TAA.Migration.SDK.Implementations.Tests/Validations/DepreciationQuotaValidationsTests.cs
+++ b/Importia.SDK/Tests/a3innuva.TAA.Migration.SDK.Implementations.Tests/Validations/DepreciationQuotaValidationsTests.cs
@@ -46,7 +46,7 @@ namespace a3innuva.TAA.Migration.SDK.Implementations.Tests
         public void Validate_AccountingQuotaAmount_required_failed()
         {
             var entity = this.CreateEntity();
-            entity.AccountingQuotaAmount = 0m;
+            entity.AccountingQuotaAmount = -1m;
 
             var errors = this.validation.Validate(entity);
 
@@ -57,7 +57,7 @@ namespace a3innuva.TAA.Migration.SDK.Implementations.Tests
         public void Validate_FiscalQuotaAmount_required_failed()
         {
             var entity = this.CreateEntity();
-            entity.FiscalQuotaAmount = 0m;
+            entity.FiscalQuotaAmount = -1m;
 
             var errors = this.validation.Validate(entity);
 
@@ -68,7 +68,7 @@ namespace a3innuva.TAA.Migration.SDK.Implementations.Tests
         public void Validate_StartDate_required_failed()
         {
             var entity = this.CreateEntity();
-            entity.StartDate = new DateTime(2101, 1, 1);
+            entity.StartDate = DateTime.MinValue;
 
             var errors = this.validation.Validate(entity);
 
@@ -79,7 +79,7 @@ namespace a3innuva.TAA.Migration.SDK.Implementations.Tests
         public void Validate_EndDate_required_failed()
         {
             var entity = this.CreateEntity();
-            entity.EndDate = new DateTime(2101, 1, 1);
+            entity.EndDate = DateTime.MinValue;
 
             var errors = this.validation.Validate(entity);
 


### PR DESCRIPTION
Se añaden métodos de validación específicos para importes y fechas de cuotas de depreciación. Ahora los importes permiten valores >= 0 y las fechas solo validan que no sean DateTime.MinValue. Se actualizan los tests para reflejar estos cambios.